### PR TITLE
fix persisting session key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Easy [toastr.js](https://github.com/CodeSeven/toastr) notifications for Laravel 
 Installation
 ------------
 
-1. Either run `composer require oriceon/toastr-5-laravel` or add `"oriceon/toastr-5-laravel": "dev-master"` to the `require` key in `composer.json` and run `composer install`
+1. Either run `composer require hotsaucejake/toastr-5-laravel` or add `"hotsaucejake/toastr-5-laravel": "dev-master"` to the `require` key in `composer.json` and run `composer install`
 2. Add `'Kamaln7\Toastr\ToastrServiceProvider',` to the `providers` key in `config/app.php` (optional for Laravel 5.5)
 3. Add `'Toastr'          => 'Kamaln7\Toastr\Facades\Toastr',` to the `aliases` key in `config/app.php` (optional for Laravel 5.5)
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "oriceon/toastr-5-laravel",
+    "name": "hotsaucejake/toastr-5-laravel",
     "description": "Easy toastr notifications for Laravel 5",
     "keywords": ["toastr", "notification", "laravel", "php"],
-    "homepage": "https://github.com/oriceon/toastr-5-laravel",
+    "homepage": "https://github.com/hotsaucejake/toastr-5-laravel",
     "license": "MIT",
     "authors": [
         {
@@ -12,6 +12,10 @@
         {
             "name": "Valentin Ivascu",
             "email": "oriceon@gmail.com"
+        },
+        {
+            "name": "HOT SAUCE JAKE",
+            "email": "get@hotsaucejake.com"
         }
     ],
     "require": {

--- a/src/Kamaln7/Toastr/Toastr.php
+++ b/src/Kamaln7/Toastr/Toastr.php
@@ -74,6 +74,9 @@ class Toastr {
         }
         $output .= '</script>';
 
+        // fix for persisting session key
+        $this->session->forget('toastr::notifications');
+
         return $output;
     }
 


### PR DESCRIPTION
- Reason(s):
  - toastr notifications show up twice when initially invoked between redirects

- Change(s):
  - forget the 'toastr::notifications' key once it's been used

- Reference(s):